### PR TITLE
Update minimum score match in DmmConfiguration

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,7 @@ services:
       - zilean_data:/app/data
     environment:
         Zilean__ElasticSearch__Url: http://elasticsearch:9200
+        Zilean__Dmm__MinimumScoreMatch: 40
     healthcheck:
       test: curl --connect-timeout 10 --silent --show-error --fail http://localhost:8181/healthchecks/ping
       timeout: 60s

--- a/src/Zilean.Shared/Features/Configuration/DmmConfiguration.cs
+++ b/src/Zilean.Shared/Features/Configuration/DmmConfiguration.cs
@@ -6,5 +6,5 @@ public class DmmConfiguration
     public bool EnableEndpoint { get; set; } = true;
     public string ScrapeSchedule { get; set; } = "0 * * * *";
     public int MaxFilteredResults { get; set; } = 200;
-    public int MinimumScoreMatch { get; set; } = 85;
+    public int MinimumScoreMatch { get; set; } = 40;
 }


### PR DESCRIPTION
The minimum score threshold for a match in the DmmConfiguration class and compose.yaml has been decreased from 85 to 40. This change affects how the software filters and displays results based on score match.
