### PR TITLE
set specific versions for apk add

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN dotnet publish -c Release --no-restore -a $TARGETARCH -o /app/out
 # Run Stage
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine3.19
 RUN apk add --update --no-cache \
-    python3=~3.11.9-r0 \
-    py3-pip \
-    curl \
+    python3=3.11.9-r1 \
+    py3-pip=23.3.1-r0 \
+    curl=8.9.0-r0 \
     && ln -sf python3 /usr/bin/python
 ENV DOTNET_RUNNING_IN_CONTAINER=true
 ENV DOTNET_gcServer=1


### PR DESCRIPTION
This fixes build issues due to incompatibilities of the newest py3-pip/curl versions with the pinned python3 version, by pinning all package versions