### PR TITLE
Fix ZurgEndpointSuffix / ZileanEndpointSuffix

### DIFF
--- a/src/Zilean.Scraper/Features/Ingestion/Processing/StreamedEntryProcessor.cs
+++ b/src/Zilean.Scraper/Features/Ingestion/Processing/StreamedEntryProcessor.cs
@@ -38,8 +38,8 @@ public class StreamedEntryProcessor(
 
             var fullUrl = _currentEndpoint.EndpointType switch
             {
-                GenericEndpointType.Zurg => $"{_currentEndpoint.Url}/debug/torrents",
-                GenericEndpointType.Zilean => $"{_currentEndpoint.Url}/torrents/all",
+                GenericEndpointType.Zurg => $"{_currentEndpoint.Url}{_configuration.Ingestion.ZurgEndpointSuffix}",
+                GenericEndpointType.Zilean => $"{_currentEndpoint.Url}{_configuration.Ingestion.ZileanEndpointSuffix}",
                 GenericEndpointType.Generic => $"{_currentEndpoint.Url}{_currentEndpoint.EndpointSuffix}",
                 _ => throw new InvalidOperationException($"Unknown endpoint type: {_currentEndpoint.EndpointType}")
             };

--- a/src/Zilean.Shared/Features/Configuration/LoggingConfiguration.cs
+++ b/src/Zilean.Shared/Features/Configuration/LoggingConfiguration.cs
@@ -35,6 +35,9 @@ public static class LoggingConfiguration
     private static void EnsureExists(string configurationFolderPath)
     {
         var loggingPath = Path.Combine(configurationFolderPath, ConfigurationLiterals.LoggingConfigFilename);
-        File.WriteAllText(loggingPath, DefaultLoggingContents);
+        if (!File.Exists(loggingPath))
+        {
+            File.WriteAllText(loggingPath, DefaultLoggingContents);
+        }
     }
 }


### PR DESCRIPTION
This PR simply makes the `ZurgEndpointSuffix` and `ZileanEndpointSuffix` values work, rather than the hard-coded defaults they're currently set to, and avoids overwriting the log config if it already exists (_and has possibly been customized_)