### PR TITLE
make db connection string dynamic using environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ riderModule.iml
 .DS_Store
 .idea/
 .env
+.vs
 
 src/Zilean.Scraper/python/
 src/Zilean.ApiService/python/

--- a/docs/Writerside/snippets/compose-file.yaml
+++ b/docs/Writerside/snippets/compose-file.yaml
@@ -10,7 +10,10 @@ services:
     container_name: zilean
     tty: true
     environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST: ${POSTGRES_HOST}         # Optional defaults to postgres
+      POSTGRES_DB: ${POSTGRES_DB}             # Optional defaults to zilean
+      POSTGRES_USER: ${POSTGRES_USER}         # Optional defaults to postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} # Optional defaults to postgres
     ports:
       - "8181:8181"
     volumes:

--- a/docs/Writerside/snippets/default-settings.json
+++ b/docs/Writerside/snippets/default-settings.json
@@ -15,7 +15,7 @@
       "EnableEndpoint": true
     },
     "Database": {
-      "ConnectionString": "Host=postgres;Database=zilean;Username=postgres;Password=$POSTGRES_PASSWORD;Include Error Detail=true;Timeout=30;CommandTimeout=3600;"
+      "ConnectionString": "Host=postgres;Database=zilean;Username=postgres;Password=postgres;Include Error Detail=true;Timeout=30;CommandTimeout=3600;"
     },
     "Torrents": {
       "EnableEndpoint": false,

--- a/docs/Writerside/snippets/settings-with-ingestion.json
+++ b/docs/Writerside/snippets/settings-with-ingestion.json
@@ -15,7 +15,7 @@
       "EnableEndpoint": true
     },
     "Database": {
-      "ConnectionString": "Host=localhost;Database=zilean;Username=postgres;Password=$POSTGRES_PASSWORD;Include Error Detail=true;Timeout=30;CommandTimeout=3600;"
+      "ConnectionString": "Host=localhost;Database=zilean;Username=postgres;Password=postgres;Include Error Detail=true;Timeout=30;CommandTimeout=3600;"
     },
     "Torrents": {
       "EnableEndpoint": true,

--- a/docs/Writerside/topics/Configuration.md
+++ b/docs/Writerside/topics/Configuration.md
@@ -67,8 +67,7 @@ _Default: `true`_
 ### Database Configuration
 **Database.ConnectionString**
 _The connection string for the PostgreSQL database._
-_$POSTGRES_PASSWORD should be replaced with the password in your .env_
-_Default: `Host=localhost;Database=zilean;Username=postgres;Password=$POSTGRES_PASSWORD;Include Error Detail=true;Timeout=30;CommandTimeout=3600;`_
+_Default: `Host=localhost;Database=zilean;Username=postgres;Password=postgres;Include Error Detail=true;Timeout=30;CommandTimeout=3600;`_
 
 The database connection string comprises of the following:
 - `Host`: The host of the database, this will usually be the `containername` if you are using docker compose of the postgres instance.

--- a/docs/Writerside/topics/Getting-Started.md
+++ b/docs/Writerside/topics/Getting-Started.md
@@ -18,12 +18,6 @@ The easiest way to get up and running with %Product% is to use the provided dock
 Ensure you have the following installed:
 - Docker, Docker Desktop or Podman
 
-First, generate your postgres password with 
-
-```bash
-echo "POSTGRES_PASSWORD=$(openssl rand -base64 42 | tr -dc A-Za-z0-9 | cut -c -32 | tr -d '\n')" > .env
-```
-
 The example compose file below can be copied, and used to get the system running locally.
 
 ```yaml

--- a/src/Zilean.Shared/Features/Configuration/DatabaseConfiguration.cs
+++ b/src/Zilean.Shared/Features/Configuration/DatabaseConfiguration.cs
@@ -2,16 +2,34 @@ namespace Zilean.Shared.Features.Configuration;
 
 public class DatabaseConfiguration
 {
-  public string ConnectionString { get; set; }
+    public string ConnectionString { get; set; }
 
-  public DatabaseConfiguration()
-  {
-    var password = Environment.GetEnvironmentVariable("POSTGRES_PASSWORD");
-    if (string.IsNullOrWhiteSpace(password))
+    public DatabaseConfiguration()
     {
-      throw new InvalidOperationException("Environment variable POSTGRES_PASSWORD is not set.");
-    }
+        var host = Environment.GetEnvironmentVariable("POSTGRES_HOST");
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            host = "postgres";
+        }
 
-    ConnectionString = $"Host=postgres;Database=zilean;Username=postgres;Password={password};Include Error Detail=true;Timeout=30;CommandTimeout=3600;";
-  }
+        var database = Environment.GetEnvironmentVariable("POSTGRES_DB");
+        if (string.IsNullOrWhiteSpace(database))
+        {
+            database = "zilean";
+        }
+
+        var username = Environment.GetEnvironmentVariable("POSTGRES_USER");
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            username = "postgres";
+        }
+
+        var password = Environment.GetEnvironmentVariable("POSTGRES_PASSWORD");
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            password = "postgres";
+        }
+
+        ConnectionString = $"Host={host};Database={database};Username={username};Password={password};Include Error Detail=true;Timeout=30;CommandTimeout=3600;";
+    }
 }

--- a/tests/Zilean.Tests/Fixtures/PostgresLifecycleFixture.cs
+++ b/tests/Zilean.Tests/Fixtures/PostgresLifecycleFixture.cs
@@ -5,9 +5,10 @@ public class PostgresLifecycleFixture : IAsyncLifetime
     private PostgreSqlContainer PostgresContainer { get; } = new PostgreSqlBuilder()
         .WithImage("postgres:16.3-alpine3.20")
         .WithPortBinding(5432, 5432)
+        .WithEnvironment("POSTGRES_HOST", "postgres")
+        .WithEnvironment("POSTGRES_DB", "zilean")
         .WithEnvironment("POSTGRES_USER", "postgres")
         .WithEnvironment("POSTGRES_PASSWORD", "postgres")
-        .WithEnvironment("POSTGRES_DB", "zilean")
         .Build();
 
     public ZileanConfiguration ZileanConfiguration { get; } = new();


### PR DESCRIPTION
I wanted to rename my postgres container to be zilean-postgres so it does not conflict with my other docker containers only to realise that postgres is hard coded in the connection string. 
This fixes this and makes it dynamic. If the value is not set it is defaulted. 