### PR TITLE
fix: PostgreSQL security hardening

### DIFF
--- a/src/Zilean.ApiService/Features/Bootstrapping/StartupService.cs
+++ b/src/Zilean.ApiService/Features/Bootstrapping/StartupService.cs
@@ -13,6 +13,15 @@ public class StartupService(
     public async Task StartingAsync(CancellationToken cancellationToken)
     {
         var logger = loggerFactory.CreateLogger<StartupService>();
+
+        // Security check — warn about insecure Postgres credentials
+        if (configuration.Database.HasInsecurePassword())
+        {
+            logger.LogWarning("SECURITY WARNING: PostgreSQL password is empty or set to the default 'postgres'. " +
+                "This is a security risk — if your database port is exposed, attackers can connect and compromise your system. " +
+                "Set a strong password via POSTGRES_PASSWORD or Zilean__Database__ConnectionString.");
+        }
+
         logger.LogInformation("Applying Migrations...");
         await using var asyncScope = serviceProvider.CreateAsyncScope();
         var dbContext = asyncScope.ServiceProvider.GetRequiredService<ZileanDbContext>();

--- a/src/Zilean.Shared/Features/Configuration/DatabaseConfiguration.cs
+++ b/src/Zilean.Shared/Features/Configuration/DatabaseConfiguration.cs
@@ -1,3 +1,5 @@
+using Npgsql;
+
 namespace Zilean.Shared.Features.Configuration;
 
 public class DatabaseConfiguration
@@ -13,5 +15,22 @@ public class DatabaseConfiguration
     }
 
     ConnectionString = $"Host=postgres;Database=zilean;Username=postgres;Password={password};Include Error Detail=true;Timeout=30;CommandTimeout=3600;";
+  }
+
+  /// <summary>
+  /// Returns true if the configured password is empty or a known insecure default.
+  /// </summary>
+  public bool HasInsecurePassword()
+  {
+    try
+    {
+      var parsed = new NpgsqlConnectionStringBuilder(ConnectionString);
+      return string.IsNullOrEmpty(parsed.Password) ||
+             string.Equals(parsed.Password, "postgres", StringComparison.OrdinalIgnoreCase);
+    }
+    catch
+    {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Warns at startup if PostgreSQL password is empty or set to the default "postgres"
- Addresses reports of crypto miners compromising exposed Postgres instances

Fixes #21, helps with #89

## Changes

- `DatabaseConfiguration.cs` - added `HasInsecurePassword()` method using `NpgsqlConnectionStringBuilder`
- `StartupService.cs` - logs a security warning at startup when insecure credentials detected

## Test plan

- Start with empty `POSTGRES_PASSWORD` -> security warning appears in logs
- Start with strong password -> no warning