### PR TITLE
feat: timezone support via TZ environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apk add --update --no-cache \
     py3-pip=~23.1 \
     curl \
     icu-libs \
+    tzdata \
     && ln -sf python3 /usr/bin/python
 ENV DOTNET_RUNNING_IN_CONTAINER=true
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false


### PR DESCRIPTION
## Summary

Adds `tzdata` package to the Docker image so the `TZ` environment variable is respected. Without it, log timestamps always show UTC regardless of TZ setting.

Fixes #100

## Changes

- `Dockerfile` - added `tzdata` to `apk add` packages

## Usage

```yaml
environment:
  - TZ=Australia/Sydney
```

## Test plan

- Set `TZ=Australia/Sydney` -> log timestamps show AEST/AEDT
- No TZ set -> timestamps remain UTC (unchanged behavior)