### PR TITLE
fix: flexible database connection string configuration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
+    <PackageVersion Include="Npgsql" Version="9.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="pythonnet" Version="3.0.4" />

--- a/src/Zilean.Shared/Features/Configuration/DatabaseConfiguration.cs
+++ b/src/Zilean.Shared/Features/Configuration/DatabaseConfiguration.cs
@@ -1,17 +1,40 @@
+using Npgsql;
+
 namespace Zilean.Shared.Features.Configuration;
 
 public class DatabaseConfiguration
 {
-  public string ConnectionString { get; set; }
+    public string ConnectionString { get; set; }
 
-  public DatabaseConfiguration()
-  {
-    var password = Environment.GetEnvironmentVariable("POSTGRES_PASSWORD");
-    if (string.IsNullOrWhiteSpace(password))
+    public DatabaseConfiguration()
     {
-      throw new InvalidOperationException("Environment variable POSTGRES_PASSWORD is not set.");
-    }
+        // Check for full connection string first (backwards compat with v3.5.0)
+        var fullConnString = Environment.GetEnvironmentVariable("Zilean__Database__ConnectionString");
+        if (!string.IsNullOrWhiteSpace(fullConnString))
+        {
+            ConnectionString = fullConnString;
+            return;
+        }
 
-    ConnectionString = $"Host=postgres;Database=zilean;Username=postgres;Password={password};Include Error Detail=true;Timeout=30;CommandTimeout=3600;";
-  }
+        // Build from individual env vars
+        var host = Environment.GetEnvironmentVariable("POSTGRES_HOST") ?? "localhost";
+        var port = Environment.GetEnvironmentVariable("POSTGRES_PORT") ?? "5432";
+        var db = Environment.GetEnvironmentVariable("POSTGRES_DB") ?? "zilean";
+        var user = Environment.GetEnvironmentVariable("POSTGRES_USER") ?? "postgres";
+        var password = Environment.GetEnvironmentVariable("POSTGRES_PASSWORD") ?? "";
+
+        var builder = new NpgsqlConnectionStringBuilder
+        {
+            Host = host,
+            Port = int.Parse(port),
+            Database = db,
+            Username = user,
+            Password = password,
+            IncludeErrorDetail = true,
+            Timeout = 30,
+            CommandTimeout = 3600,
+        };
+
+        ConnectionString = builder.ConnectionString;
+    }
 }

--- a/src/Zilean.Shared/Zilean.Shared.csproj
+++ b/src/Zilean.Shared/Zilean.Shared.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="pythonnet" />
     <PackageReference Include="CliWrap" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql" />
     <PackageReference Include="Serilog.Sinks.Spectre" />
     <PackageReference Include="SimCube.Aspire" />
     <PackageReference Include="System.Private.Uri" />

--- a/tests/Zilean.Tests/Tests/ConfigurationTests.cs
+++ b/tests/Zilean.Tests/Tests/ConfigurationTests.cs
@@ -130,6 +130,135 @@ public class ConfigurationTests
         Directory.Delete(testsFolder, true);
     }
 
+    [Fact]
+    public void database_configuration_defaults_without_env_vars()
+    {
+        var savedVars = ClearDatabaseEnvVars();
+        try
+        {
+            var dbConfig = new DatabaseConfiguration();
+
+            dbConfig.ConnectionString.Should().NotBeNullOrWhiteSpace();
+            dbConfig.ConnectionString.Should().Contain("Host=localhost");
+            dbConfig.ConnectionString.Should().Contain("Database=zilean");
+            dbConfig.ConnectionString.Should().Contain("Username=postgres");
+        }
+        finally
+        {
+            RestoreDatabaseEnvVars(savedVars);
+        }
+    }
+
+    [Fact]
+    public void database_configuration_respects_full_connection_string_env_var()
+    {
+        var savedVars = ClearDatabaseEnvVars();
+        try
+        {
+            var expected = "Host=myhost;Database=mydb;Username=myuser;Password=mypass;";
+            Environment.SetEnvironmentVariable("Zilean__Database__ConnectionString", expected);
+
+            var dbConfig = new DatabaseConfiguration();
+
+            dbConfig.ConnectionString.Should().Be(expected);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("Zilean__Database__ConnectionString", null);
+            RestoreDatabaseEnvVars(savedVars);
+        }
+    }
+
+    [Fact]
+    public void database_configuration_builds_from_individual_env_vars()
+    {
+        var savedVars = ClearDatabaseEnvVars();
+        try
+        {
+            Environment.SetEnvironmentVariable("POSTGRES_HOST", "db.example.com");
+            Environment.SetEnvironmentVariable("POSTGRES_PORT", "5433");
+            Environment.SetEnvironmentVariable("POSTGRES_DB", "mydb");
+            Environment.SetEnvironmentVariable("POSTGRES_USER", "admin");
+            Environment.SetEnvironmentVariable("POSTGRES_PASSWORD", "secret");
+
+            var dbConfig = new DatabaseConfiguration();
+
+            dbConfig.ConnectionString.Should().Contain("Host=db.example.com");
+            dbConfig.ConnectionString.Should().Contain("Port=5433");
+            dbConfig.ConnectionString.Should().Contain("Database=mydb");
+            dbConfig.ConnectionString.Should().Contain("Username=admin");
+            dbConfig.ConnectionString.Should().Contain("Password=secret");
+        }
+        finally
+        {
+            RestoreDatabaseEnvVars(savedVars);
+        }
+    }
+
+    [Fact]
+    public void database_configuration_escapes_special_chars_in_password()
+    {
+        var savedVars = ClearDatabaseEnvVars();
+        try
+        {
+            Environment.SetEnvironmentVariable("POSTGRES_PASSWORD", "p@ss#w0rd!&");
+
+            var dbConfig = new DatabaseConfiguration();
+
+            dbConfig.ConnectionString.Should().NotBeNullOrWhiteSpace();
+
+            // Verify it round-trips correctly
+            var parsed = new Npgsql.NpgsqlConnectionStringBuilder(dbConfig.ConnectionString);
+            parsed.Password.Should().Be("p@ss#w0rd!&");
+        }
+        finally
+        {
+            RestoreDatabaseEnvVars(savedVars);
+        }
+    }
+
+    [Fact]
+    public void database_configuration_full_connection_string_takes_priority_over_individual_vars()
+    {
+        var savedVars = ClearDatabaseEnvVars();
+        try
+        {
+            var expected = "Host=priority-host;Database=prioritydb;Username=user;Password=pass;";
+            Environment.SetEnvironmentVariable("Zilean__Database__ConnectionString", expected);
+            Environment.SetEnvironmentVariable("POSTGRES_HOST", "ignored-host");
+            Environment.SetEnvironmentVariable("POSTGRES_PASSWORD", "ignored-pass");
+
+            var dbConfig = new DatabaseConfiguration();
+
+            dbConfig.ConnectionString.Should().Be(expected);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("Zilean__Database__ConnectionString", null);
+            RestoreDatabaseEnvVars(savedVars);
+        }
+    }
+
+    private static Dictionary<string, string?> ClearDatabaseEnvVars()
+    {
+        var vars = new[] { "POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DB", "POSTGRES_USER", "POSTGRES_PASSWORD", "Zilean__Database__ConnectionString" };
+        var saved = new Dictionary<string, string?>();
+        foreach (var v in vars)
+        {
+            saved[v] = Environment.GetEnvironmentVariable(v);
+            Environment.SetEnvironmentVariable(v, null);
+        }
+        return saved;
+    }
+
+    private static void RestoreDatabaseEnvVars(Dictionary<string, string?> saved)
+    {
+        foreach (var (key, value) in saved)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+
     private static string CreateTestFolder()
     {
         var testsFolder = Path.Combine(Path.GetTempPath(), "Zilean.Tests");


### PR DESCRIPTION
## Summary

- Supports `Zilean__Database__ConnectionString` env var as primary config (backwards compatible with v3.5.0)
- Falls back to individual `POSTGRES_*` env vars (`POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`) with sensible defaults
- Uses `NpgsqlConnectionStringBuilder` to properly escape special characters in passwords
- Constructor no longer throws on missing env vars, empty password is valid for trust auth
- Default host is `localhost` instead of hardcoded `postgres`

Fixes #85, #97, #99

## Changes

- `DatabaseConfiguration.cs` - rewritten to support flexible connection config via `NpgsqlConnectionStringBuilder`
- `Zilean.Shared.csproj` - added Npgsql package reference
- `Directory.Packages.props` - added Npgsql package version
- `ConfigurationTests.cs` - 5 new tests for DB config scenarios

## Test plan

- Set `Zilean__Database__ConnectionString` with full connection string -> connects successfully
- Set individual `POSTGRES_*` env vars -> builds correct connection string
- Use password with special chars (`#`, `!`, `&`) -> connects without auth errors
- Omit all DB env vars -> defaults to localhost:5432/zilean/postgres