### PR TITLE
feat: incremental DMM sync via git clone/pull

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --update --no-cache \
     python3=~3.11 \
     py3-pip=~23.1 \
     curl \
+    git \
     icu-libs \
     && ln -sf python3 /usr/bin/python
 ENV DOTNET_RUNNING_IN_CONTAINER=true

--- a/src/Zilean.Scraper/Features/Ingestion/Dmm/DmmFileDownloader.cs
+++ b/src/Zilean.Scraper/Features/Ingestion/Dmm/DmmFileDownloader.cs
@@ -2,7 +2,10 @@ namespace Zilean.Scraper.Features.Ingestion.Dmm;
 
 public class DmmFileDownloader(ILogger<DmmFileDownloader> logger, ZileanConfiguration configuration)
 {
-    private const string Filename = "main.zip";
+    private const string RepoUrl = "https://github.com/debridmediamanager/hashlists.git";
+    private const string RepoBranch = "main";
+    private const int MaxRetryAttempts = 5;
+    private static readonly TimeSpan _initialRetryDelay = TimeSpan.FromSeconds(5);
 
     private static readonly IReadOnlyCollection<string> _filesToIgnore =
     [
@@ -10,96 +13,212 @@ public class DmmFileDownloader(ILogger<DmmFileDownloader> logger, ZileanConfigur
         "404.html",
         "dedupe.sh",
         "CNAME",
+        ".git",
     ];
 
     public async Task<string> DownloadFileToTempPath(DmmLastImport? dmmLastImport, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Downloading DMM Hashlists");
+        logger.LogInformation("Syncing DMM Hashlists");
 
-        var tempDirectory = Path.Combine(Path.GetTempPath(), "DMMHashlists");
+        var dataDirectory = Path.Combine(AppContext.BaseDirectory, "data", "DMMHashlists");
 
         if (dmmLastImport is not null)
         {
             if (DateTime.UtcNow - dmmLastImport.OccuredAt < TimeSpan.FromMinutes(configuration.Dmm.MinimumReDownloadIntervalMinutes))
             {
-                logger.LogInformation("DMM Hashlists download not required as last download was less than the configured {Minutes} minutes re-download interval set in DMM Configuration.", configuration.Dmm.MinimumReDownloadIntervalMinutes);
-                return tempDirectory;
+                logger.LogInformation("DMM Hashlists sync not required as last sync was less than the configured {Minutes} minutes re-download interval set in DMM Configuration.", configuration.Dmm.MinimumReDownloadIntervalMinutes);
+                return dataDirectory;
             }
         }
 
-        var client = CreateHttpClient();
-        var response = await client.GetAsync(Filename, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        var repoDirectory = Path.Combine(dataDirectory, "repo");
+        var gitDirectory = Path.Combine(repoDirectory, ".git");
 
-        EnsureDirectoryIsClean(tempDirectory);
+        var githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+        var repoUrlWithAuth = GetRepoUrlWithAuth(githubToken);
 
-        response.EnsureSuccessStatusCode();
-
-        var tempFilePath = Path.Combine(tempDirectory, "DMMHashlists.zip");
-        await using (var stream = await response.Content.ReadAsStreamAsync(cancellationToken))
-        await using (var fileStream = new FileStream(tempFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
+        if (Directory.Exists(gitDirectory))
         {
-            await stream.CopyToAsync(fileStream, cancellationToken);
+            logger.LogInformation("Repository exists, pulling latest changes");
+            await GitPullAsync(repoDirectory, repoUrlWithAuth, cancellationToken);
+        }
+        else
+        {
+            logger.LogInformation("Repository does not exist, cloning");
+            EnsureDirectoryIsClean(dataDirectory);
+            await GitCloneAsync(repoUrlWithAuth, repoDirectory, cancellationToken);
         }
 
-        ExtractZipFile(tempFilePath, tempDirectory);
+        CopyFilesToDataDirectory(repoDirectory, dataDirectory);
 
-        File.Delete(tempFilePath);
+        logger.LogInformation("Synced Repository to {DataDirectory}", dataDirectory);
 
-        foreach (var file in _filesToIgnore)
-        {
-            CleanRepoExtras(tempDirectory, file);
-        }
-
-        logger.LogInformation("Downloaded and extracted Repository to {TempDirectory}", tempDirectory);
-
-        return tempDirectory;
+        return dataDirectory;
     }
 
-    private static void ExtractZipFile(string zipFilePath, string extractPath)
+    private string GetRepoUrlWithAuth(string? githubToken)
     {
-        using var fileStream = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        using var archive = new ZipArchive(fileStream, ZipArchiveMode.Read);
-
-        foreach (var entry in archive.Entries)
+        if (string.IsNullOrWhiteSpace(githubToken))
         {
-            var entryPath = Path.Combine(extractPath, Path.GetFileName(entry.FullName));
-            if (!entry.FullName.EndsWith('/'))
+            logger.LogDebug("No GITHUB_TOKEN environment variable found. Git operations may be rate limited");
+            return RepoUrl;
+        }
+
+        logger.LogInformation("Using GITHUB_TOKEN for authenticated Git operations to avoid rate limiting");
+        // Format: https://<token>@github.com/owner/repo.git
+        return RepoUrl.Replace("https://", $"https://{githubToken}@");
+    }
+
+    private async Task GitCloneAsync(string repoUrl, string targetDirectory, CancellationToken cancellationToken)
+    {
+        await ExecuteWithRetryAsync(async () =>
+        {
+            var process = new Process
             {
-                entry.ExtractToFile(entryPath, true);
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = $"clone --depth 1 --branch {RepoBranch} --single-branch \"{repoUrl}\" \"{targetDirectory}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                }
+            };
+
+            await RunGitProcessAsync(process, "clone", cancellationToken);
+        }, "clone", targetDirectory, cancellationToken);
+    }
+
+    private async Task GitPullAsync(string repoDirectory, string repoUrl, CancellationToken cancellationToken)
+    {
+        // Update the remote URL in case the token changed
+        var setUrlProcess = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"-C \"{repoDirectory}\" remote set-url origin \"{repoUrl}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
             }
-        }
-    }
-
-    private static void CleanRepoExtras(string tempDirectory, string fileName)
-    {
-        var repoIndex = Path.Combine(tempDirectory, fileName);
-
-        if (File.Exists(repoIndex))
-        {
-            File.Delete(repoIndex);
-        }
-    }
-
-    private static void EnsureDirectoryIsClean(string tempDirectory)
-    {
-        if (Directory.Exists(tempDirectory))
-        {
-            Directory.Delete(tempDirectory, true);
-        }
-
-        Directory.CreateDirectory(tempDirectory);
-    }
-
-    private static HttpClient CreateHttpClient()
-    {
-        var httpClient = new HttpClient
-        {
-            BaseAddress = new Uri("https://github.com/debridmediamanager/hashlists/zipball/main/"),
-            Timeout = TimeSpan.FromMinutes(10),
         };
 
-        httpClient.DefaultRequestHeaders.Add("Accept-Encoding", "gzip");
-        httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("curl/7.54");
-        return httpClient;
+        await RunGitProcessAsync(setUrlProcess, "remote set-url", cancellationToken);
+
+        // Pull latest changes with retry
+        await ExecuteWithRetryAsync(async () =>
+        {
+            var pullProcess = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = $"-C \"{repoDirectory}\" pull --ff-only",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                }
+            };
+
+            await RunGitProcessAsync(pullProcess, "pull", cancellationToken);
+        }, "pull", repoDirectory, cancellationToken);
+    }
+
+    private async Task RunGitProcessAsync(Process process, string operation, CancellationToken cancellationToken)
+    {
+        process.Start();
+
+        var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        var output = await outputTask;
+        var error = await errorTask;
+
+        if (process.ExitCode != 0)
+        {
+            logger.LogError("Git {Operation} failed with exit code {ExitCode}: {Error}", operation, process.ExitCode, error);
+            throw new InvalidOperationException($"Git {operation} failed: {error}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(output))
+        {
+            logger.LogDebug("Git {Operation} output: {Output}", operation, output);
+        }
+    }
+
+    private async Task ExecuteWithRetryAsync(Func<Task> operation, string operationName, string targetDirectory, CancellationToken cancellationToken)
+    {
+        var attempt = 0;
+        var delay = _initialRetryDelay;
+
+        while (true)
+        {
+            attempt++;
+            try
+            {
+                await operation();
+                return;
+            }
+            catch (InvalidOperationException ex) when (attempt < MaxRetryAttempts && !cancellationToken.IsCancellationRequested)
+            {
+                logger.LogWarning(
+                    "Git {Operation} attempt {Attempt}/{MaxAttempts} failed. Retrying in {Delay} seconds... Error: {Error}",
+                    operationName,
+                    attempt,
+                    MaxRetryAttempts,
+                    delay.TotalSeconds,
+                    ex.Message);
+
+                // Clean up the target directory before retry for clone operations
+                if (operationName == "clone" && Directory.Exists(targetDirectory))
+                {
+                    try
+                    {
+                        Directory.Delete(targetDirectory, true);
+                    }
+                    catch (Exception cleanupEx)
+                    {
+                        logger.LogWarning("Failed to clean up directory {Directory} before retry: {Error}", targetDirectory, cleanupEx.Message);
+                    }
+                }
+
+                await Task.Delay(delay, cancellationToken);
+                delay = TimeSpan.FromSeconds(Math.Min(delay.TotalSeconds * 2, 60)); // Exponential backoff, max 60 seconds
+            }
+        }
+    }
+
+    private void CopyFilesToDataDirectory(string repoDirectory, string dataDirectory)
+    {
+        var files = Directory.GetFiles(repoDirectory);
+
+        foreach (var file in files)
+        {
+            var fileName = Path.GetFileName(file);
+
+            if (_filesToIgnore.Contains(fileName))
+            {
+                continue;
+            }
+
+            var destPath = Path.Combine(dataDirectory, fileName);
+            File.Copy(file, destPath, true);
+        }
+    }
+
+    private static void EnsureDirectoryIsClean(string directory)
+    {
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, true);
+        }
+
+        Directory.CreateDirectory(directory);
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the ~1.2GB zip download with `git clone --depth 1` on first run and `git pull --ff-only` on subsequent syncs
- Repo persisted in `data/DMMHashlists/repo/` so it survives restarts
- `GITHUB_TOKEN` env var support for authenticated requests (5,000 req/hr vs 60 unauthenticated, eliminates 429 rate limiting)
- Exponential backoff retry (5 attempts, max 60s delay)

Fixes #101

## Changes

- `DmmFileDownloader.cs` - replaced HTTP zip download with git clone/pull
- `Dockerfile` - added `git` package

## Test plan

- First run with no existing repo -> clones successfully (~90s)
- Subsequent run -> pulls only new changes (seconds)
- Set `GITHUB_TOKEN` -> authenticated requests, no 429s
- Remove `data/DMMHashlists/repo/` -> re-clones from scratch on next sync