### PR TITLE
fix: preserve custom logging.json across restarts

### DIFF
--- a/src/Zilean.Shared/Features/Configuration/LoggingConfiguration.cs
+++ b/src/Zilean.Shared/Features/Configuration/LoggingConfiguration.cs
@@ -35,6 +35,9 @@ public static class LoggingConfiguration
     private static void EnsureExists(string configurationFolderPath)
     {
         var loggingPath = Path.Combine(configurationFolderPath, ConfigurationLiterals.LoggingConfigFilename);
-        File.WriteAllText(loggingPath, DefaultLoggingContents);
+        if (!File.Exists(loggingPath))
+        {
+            File.WriteAllText(loggingPath, DefaultLoggingContents);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Only writes default `logging.json` if the file doesn't already exist
- Preserves user customizations across container restarts

Partially addresses #96

## Changes

- `LoggingConfiguration.cs` - added existence check before writing defaults

## Test plan

- Delete `logging.json`, restart -> default file created
- Customize `logging.json`, restart -> customizations preserved